### PR TITLE
Refactoring: remove hard coded API path

### DIFF
--- a/src/redux/Category/CategoryAction.js
+++ b/src/redux/Category/CategoryAction.js
@@ -1,22 +1,23 @@
 import Axios from "axios"
+import API_PATH from '../api'
 
 export const fetchCategoriesByComapnyId = (id) => {
-    return dispatch=>{
+    return dispatch => {
         dispatch({
-            type:"FETCH_CATEGORIES_BY_COMPANY_ID",
-            payload : new Promise((resolve , reject) => {
-                Axios.get(`https://localhost:44351/Category/Company/${id}`,{
+            type: "FETCH_CATEGORIES_BY_COMPANY_ID",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/Category/Company/${id}`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then(res=>{
-                    resolve(res.data);
-                    
-                })
-                .catch(err => {
-                    if(err.response.data == "Not Found"){
-                        resolve([])
-                    }
-                })
+                    .then(res => {
+                        resolve(res.data);
+
+                    })
+                    .catch(err => {
+                        if (err.response.data == "Not Found") {
+                            resolve([])
+                        }
+                    })
             })
         })
     }
@@ -25,17 +26,17 @@ export const fetchCategoriesByComapnyId = (id) => {
 export const fetchCategories = () => {
     return dispatch => {
         dispatch({
-            type : "FETCH_CATEGORIES",
-            payload : new Promise((resolve , reject) => {
-                Axios.get(`https://localhost:44351/Category/`,{
+            type: "FETCH_CATEGORIES",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/Category/`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then( res => {
-                    resolve(res.data)
-                } )
-                .catch(err => {
-                    resolve([])
-                })
+                    .then(res => {
+                        resolve(res.data)
+                    })
+                    .catch(err => {
+                        resolve([])
+                    })
             })
         })
     }

--- a/src/redux/Company/CompanyAction.js
+++ b/src/redux/Company/CompanyAction.js
@@ -1,58 +1,59 @@
 import Axios from 'axios'
+import API_PATH from '../api'
 
 export const fetchAllCompanies = () => {
-    return dispatch =>{
+    return dispatch => {
         dispatch({
-            type:"FETCH_COMPANIES",
-            payload: new Promise((resolve , reject)=>{
-                Axios.get('https://localhost:44351/Company/',{
+            type: "FETCH_COMPANIES",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/Company/`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then(response => {
-                    const companies = response.data
-                    resolve(companies)
-                })
-                .catch(err => {
-                    const errMzg = err.message
-                })
+                    .then(response => {
+                        const companies = response.data
+                        resolve(companies)
+                    })
+                    .catch(err => {
+                        const errMzg = err.message
+                    })
             })
         })
     }
 }
- 
+
 
 export const createCompany = (company) => {
     return dispatch => {
         dispatch({
-            type : "CREATE_COMPANY",
-            payload : new Promise((resolve , reject) =>{
-                Axios.post('https://localhost:44351/Company/' , company)
-                .then(response => {
-                    const CreatedCompany = response.data
-                    resolve(CreatedCompany)
-                })
-                .catch(err => {
-                    const errMzg = err.message
-                })
+            type: "CREATE_COMPANY",
+            payload: new Promise((resolve, reject) => {
+                Axios.post(`${API_PATH}/Company/`, company)
+                    .then(response => {
+                        const CreatedCompany = response.data
+                        resolve(CreatedCompany)
+                    })
+                    .catch(err => {
+                        const errMzg = err.message
+                    })
             })
         })
     }
 }
 
-export const deleteCompany = (id) =>{
+export const deleteCompany = (id) => {
     alert(id)
     return dispatch => {
         dispatch({
-            type : "DELETE_COMPANY",
-            payload : new Promise((resolve , reject) =>{
-                Axios.delete(`https://localhost:44351/Company/${id}`)
-                .then(response => { 
-                    const deletedCompany = response.data
-                    resolve(deletedCompany)
-                })
-                .catch(err => {
-                    const errMzg = err.message
-                })
+            type: "DELETE_COMPANY",
+            payload: new Promise((resolve, reject) => {
+                Axios.delete(`${API_PATH}/Company/${id}`)
+                    .then(response => {
+                        const deletedCompany = response.data
+                        resolve(deletedCompany)
+                    })
+                    .catch(err => {
+                        const errMzg = err.message
+                    })
             })
         })
     }

--- a/src/redux/KnowledgeBase/KnowledgeBaseAction.js
+++ b/src/redux/KnowledgeBase/KnowledgeBaseAction.js
@@ -1,24 +1,25 @@
 import Axios from "axios"
+import API_PATH from '../api'
 
-export  const createArticle = (article) => {
-    // those things should be from automatically in future
-    article.ArticleId = "99988"
-    article.CreatedBy = "hu"
-    article.AcceptedBy="67892s"
-    article.CreatedDate=new Date().toJSON().slice(0,10).replace(/-/g,'-')
-    article.AcceptedDate="2016-09-09"
-    article.LastEditedDate = "2016-09-09"
-    article.LastEditedBy = "heycq567"
-    article.ProductID = "yuhcsa778878"
-    console.log(article)
-  return () =>{
-    Axios.post('https://localhost:44351/Article/',article)
-    .then(response => {
+export const createArticle = (article) => {
+  // those things should be from automatically in future
+  article.ArticleId = "99988"
+  article.CreatedBy = "hu"
+  article.AcceptedBy = "67892s"
+  article.CreatedDate = new Date().toJSON().slice(0, 10).replace(/-/g, '-')
+  article.AcceptedDate = "2016-09-09"
+  article.LastEditedDate = "2016-09-09"
+  article.LastEditedBy = "heycq567"
+  article.ProductID = "yuhcsa778878"
+  console.log(article)
+  return () => {
+    Axios.post(`${API_PATH}/Article/`, article)
+      .then(response => {
         const posts = response.data
         console.log(posts)
-    })
-    .catch(err => {
+      })
+      .catch(err => {
         const errMzg = err.message
-    })
+      })
   }
 }

--- a/src/redux/Module/ModuleAction.js
+++ b/src/redux/Module/ModuleAction.js
@@ -1,23 +1,24 @@
 import Axios from "axios"
+import API_PATH from '../api'
 
 export const fetchModulesByComapnyId = (id) => {
-    return dispatch=>{
+    return dispatch => {
         dispatch({
-            type:"FETCH_MODULES_BY_COMPANY_ID",
-            payload : new Promise((resolve , reject) => {
-                Axios.get(`https://localhost:44351/Module/Company/${id}`,{
+            type: "FETCH_MODULES_BY_COMPANY_ID",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/Module/Company/${id}`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then(res=>{
+                    .then(res => {
 
-                    resolve(res.data);
-                    
-                })
-                .catch(err => {
-                    if(err.response.data == "Not Found"){
-                        resolve([])
-                    }
-                })
+                        resolve(res.data);
+
+                    })
+                    .catch(err => {
+                        if (err.response.data == "Not Found") {
+                            resolve([])
+                        }
+                    })
             })
         })
     }
@@ -26,17 +27,17 @@ export const fetchModulesByComapnyId = (id) => {
 export const fetchModules = () => {
     return dispatch => {
         dispatch({
-            type : "FETCH_MODULES",
-            payload : new Promise((resolve , reject) => {
-                Axios.get(`https://localhost:44351/Module/`,{
+            type: "FETCH_MODULES",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/Module/`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then( res => {
-                    resolve(res.data)
-                } )
-                .catch(err => {
-                    resolve([])
-                })
+                    .then(res => {
+                        resolve(res.data)
+                    })
+                    .catch(err => {
+                        resolve([])
+                    })
             })
         })
     }

--- a/src/redux/Product/ProductAction.js
+++ b/src/redux/Product/ProductAction.js
@@ -1,22 +1,23 @@
 import Axios from "axios"
+import API_PATH from '../api'
 
 export const fetchProductsByComapnyId = (id) => {
-    return dispatch=>{
+    return dispatch => {
         dispatch({
-            type:"FETCH_PRODUCTS_BY_COMPANY_ID",
-            payload : new Promise((resolve , reject) => {
-                Axios.get(`https://localhost:44351/Product/Company/${id}`,{
+            type: "FETCH_PRODUCTS_BY_COMPANY_ID",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/Product/Company/${id}`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then(res=>{
-                    resolve(res.data);
-                    
-                })
-                .catch(err => {
-                    if(err.response.data == "Not Found"){
-                        resolve([])
-                    }
-                })
+                    .then(res => {
+                        resolve(res.data);
+
+                    })
+                    .catch(err => {
+                        if (err.response.data == "Not Found") {
+                            resolve([])
+                        }
+                    })
             })
         })
     }
@@ -25,17 +26,17 @@ export const fetchProductsByComapnyId = (id) => {
 export const fetchProducts = () => {
     return dispatch => {
         dispatch({
-            type : "FETCH_PRODUCTS",
-            payload : new Promise((resolve , reject) => {
-                Axios.get(`https://localhost:44351/Product/`,{
+            type: "FETCH_PRODUCTS",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/Product/`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then( res => {
-                    resolve(res.data)
-                } )
-                .catch(err => {
-                    resolve([])
-                })
+                    .then(res => {
+                        resolve(res.data)
+                    })
+                    .catch(err => {
+                        resolve([])
+                    })
             })
         })
     }

--- a/src/redux/Ticket/TicketAction.js
+++ b/src/redux/Ticket/TicketAction.js
@@ -1,8 +1,9 @@
 import Axios from "axios"
+import API_PATH from '../api'
 
 export const createTicket = (ticket) => {
     return () => {
-        Axios.post("https://localhost:44351/Ticket", ticket)
+        Axios.post(`${API_PATH}/Ticket/`, ticket)
             .then(res => {
                 console.log(res.data)
             })
@@ -14,7 +15,7 @@ export const fetchAllTickets = () => {
         dispatch({
             type: "FETCH_TICKETS",
             payload: new Promise((resolve, reject) => {
-                Axios.get('https://localhost:5001/Ticket/')
+                Axios.get(`${API_PATH}/Ticket/`)
                     .then(response => {
                         const tickets = response.data
                         resolve(tickets)

--- a/src/redux/User/UserAction.js
+++ b/src/redux/User/UserAction.js
@@ -1,17 +1,18 @@
 import Axios from "axios"
+import API_PATH from '../api'
 
 export const createUser = (user) => {
-    return dispatch=>{
+    return dispatch => {
         dispatch({
-            type:"CREATE_USER",
-            payload : new Promise((resolve , reject) => {
-                Axios.post("https://localhost:44351/User/Register",user)
-                .then(res=>{
-                    resolve(res.data)
-                })
-                .catch(err => {
-                    const errMzg = err.message
-                })
+            type: "CREATE_USER",
+            payload: new Promise((resolve, reject) => {
+                Axios.post(`${API_PATH}/User/Register`, user)
+                    .then(res => {
+                        resolve(res.data)
+                    })
+                    .catch(err => {
+                        const errMzg = err.message
+                    })
             })
         })
     }
@@ -19,20 +20,20 @@ export const createUser = (user) => {
 
 
 export const deleteUser = (user) => {
-    return dispatch =>{
+    return dispatch => {
         dispatch({
-            type:"DELETE_USER",
-            payload: new Promise((resolve , reject)=>{
-                Axios.delete(`https://localhost:44351/User/${user}`,{
+            type: "DELETE_USER",
+            payload: new Promise((resolve, reject) => {
+                Axios.delete(`${API_PATH}/User/${user}`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then(response => {
-                    const users = response.data
-                    resolve(users)
-                })
-                .catch(err => {
-                    const errMzg = err.message
-                })
+                    .then(response => {
+                        const users = response.data
+                        resolve(users)
+                    })
+                    .catch(err => {
+                        const errMzg = err.message
+                    })
             })
         })
     }
@@ -40,23 +41,23 @@ export const deleteUser = (user) => {
 
 
 export const fetchAllUsers = () => {
-    return dispatch =>{
+    return dispatch => {
         dispatch({
-            type:"FETCH_USERS",
-            payload: new Promise((resolve , reject)=>{
-                Axios.get('https://localhost:44351/User/' , {
+            type: "FETCH_USERS",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/User/`, {
                     headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
                 })
-                .then(response => {
-                    console.log(response)
-                    resolve(response.data)
+                    .then(response => {
+                        console.log(response)
+                        resolve(response.data)
 
-                })
-                .catch(err => {
-                    
-                    resolve(err.response.data)
-                    
-                })
+                    })
+                    .catch(err => {
+
+                        resolve(err.response.data)
+
+                    })
             })
         })
     }
@@ -65,38 +66,38 @@ export const fetchAllUsers = () => {
 export const loginUser = (loginDetails) => {
     return dispatch => {
         dispatch({
-            type:"LOGIN_USER",
-            payload : new Promise((resolve , reject)=>{
-                Axios.post("https://localhost:44351/User/Login" , loginDetails)
-                .then(response => {
-                    resolve(response.data)
-                })
-                .catch(err => {
-                    const errMzg = err.message
-                })
+            type: "LOGIN_USER",
+            payload: new Promise((resolve, reject) => {
+                Axios.post(`${API_PATH}/User/Login`, loginDetails)
+                    .then(response => {
+                        resolve(response.data)
+                    })
+                    .catch(err => {
+                        const errMzg = err.message
+                    })
             })
         })
     }
 }
 
-export const getUserByUserName = (userName) =>{
+export const getUserByUserName = (userName) => {
     return dispatch => {
         dispatch({
-            type : "GET_USER_BY_USER_NAME",
-            payload : new Promise ((resolve , reject) => {
-                Axios.get(`https://localhost:44351/user/${ userName }` , {
-                headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
-            }).then(res => {
-                resolve(res.data)
-            })
+            type: "GET_USER_BY_USER_NAME",
+            payload: new Promise((resolve, reject) => {
+                Axios.get(`${API_PATH}/user/${userName}`, {
+                    headers: { 'Authorization': 'Bearer ' + localStorage.getItem("Token") }
+                }).then(res => {
+                    resolve(res.data)
+                })
             })
         })
     }
 }
 
 export const logOutUser = () => {
-    return  {
-        type : "LOGOUT_USER",
-        payload : null
+    return {
+        type: "LOGOUT_USER",
+        payload: null
     }
 }

--- a/src/redux/api.js
+++ b/src/redux/api.js
@@ -1,0 +1,2 @@
+const API_PATH = "https://localhost:5001";
+export default API_PATH;


### PR DESCRIPTION
Now we can change the API PATH by editing a single line.

Suggestion: we should use a linter. Coz vscode auto formats some stuff everytime I save. Take a look at [Prettier](https://github.com/prettier/prettier)

